### PR TITLE
XAS: Update Imports and Apply Minor Fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ readme = 'README.md'
 requires-python = '>=3.9'
 
 [project.entry-points.'aiida.calculations']
-"xspec.xspectracalculation" = "aiida_qe_xspec.calculations.xspectra:XspectraCalculation"
+"xspec.xspectra" = "aiida_qe_xspec.calculations.xspectra:XspectraCalculation"
 
 [project.entry-points.'aiida.data']
 

--- a/src/aiida_qe_xspec/workflows/xspectra/base.py
+++ b/src/aiida_qe_xspec/workflows/xspectra/base.py
@@ -8,7 +8,7 @@ from aiida.plugins import CalculationFactory
 from aiida_quantumespresso.calculations.functions.create_kpoints_from_distance import create_kpoints_from_distance
 from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin
 
-XspectraCalculation = CalculationFactory('quantumespresso.xspectra')
+XspectraCalculation = CalculationFactory('xspec.xspectra')
 
 
 class XspectraBaseWorkChain(ProtocolMixin, BaseRestartWorkChain):

--- a/src/aiida_qe_xspec/workflows/xspectra/core.py
+++ b/src/aiida_qe_xspec/workflows/xspectra/core.py
@@ -12,14 +12,14 @@ from aiida.orm.nodes.data.base import to_aiida_type
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 import yaml
 
-from aiida_quantumespresso.calculations.functions.xspectra.get_powder_spectrum import get_powder_spectrum
-from aiida_quantumespresso.calculations.functions.xspectra.merge_spectra import merge_spectra
+from aiida_qe_xspec.calculations.functions.xspectra.get_powder_spectrum import get_powder_spectrum
+from aiida_qe_xspec.calculations.functions.xspectra.merge_spectra import merge_spectra
 from aiida_quantumespresso.utils.mapping import prepare_process_inputs
 from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin, recursive_merge
 
 PwCalculation = CalculationFactory('quantumespresso.pw')
 PwBaseWorkChain = WorkflowFactory('quantumespresso.pw.base')
-XspectraBaseWorkChain = WorkflowFactory('quantumespresso.xspectra.base')
+XspectraBaseWorkChain = WorkflowFactory('xspec.xspectra.base')
 HubbardStructureData = DataFactory('quantumespresso.hubbard_structure')
 
 
@@ -308,7 +308,7 @@ class XspectraCoreWorkChain(ProtocolMixin, WorkChain):
         :param pw_code: the ``Code`` instance configured for the ``quantumespresso.pw``
                         plugin.
         :param xs_code: the ``Code`` instance configured for the
-                        ``quantumespresso.xspectra`` plugin.
+                        ``xspec.xspectra`` plugin.
         :param structure: the ``StructureData`` instance to use.
         :param upf2plotcore_code: the aiida-shell ``Code`` instance configured for the
                                   upf2plotcore.sh shell script, used to generate the core

--- a/src/aiida_qe_xspec/workflows/xspectra/crystal.py
+++ b/src/aiida_qe_xspec/workflows/xspectra/crystal.py
@@ -17,8 +17,8 @@ from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin, recur
 PwCalculation = CalculationFactory('quantumespresso.pw')
 PwBaseWorkChain = WorkflowFactory('quantumespresso.pw.base')
 PwRelaxWorkChain = WorkflowFactory('quantumespresso.pw.relax')
-XspectraBaseWorkChain = WorkflowFactory('quantumespresso.xspectra.base')
-XspectraCoreWorkChain = WorkflowFactory('quantumespresso.xspectra.core')
+XspectraBaseWorkChain = WorkflowFactory('xspec.xspectra.base')
+XspectraCoreWorkChain = WorkflowFactory('xspec.xspectra.core')
 XyData = DataFactory('core.array.xy')
 
 
@@ -685,7 +685,7 @@ class XspectraCrystalWorkChain(ProtocolMixin, WorkChain):
                 new_scf_params['SYSTEM']['starting_magnetization'] = {abs_atom_marker : 1}
 
             # remove any duplicates created from the "core_hole_treatments.yaml" defaults
-            new_scf_params_keys = [k for k in new_scf_params['SYSTEM'].keys()]
+            new_scf_params_keys = list(new_scf_params['SYSTEM'].keys())
             for key in new_scf_params_keys:
                 if 'starting_magnetization(' in key:
                     new_scf_params['SYSTEM'].pop(key, None)


### PR DESCRIPTION
Updates the import statements for the XSpectra workflows and changes the XspectraCalculation entry point to match the formatting of other plugins.

Additionally, also applies minor bugfixes from aiida-quantumespresso PR 1047 (https://github.com/aiidateam/aiida-quantumespresso/pull/1047)