### PR TITLE
XAS: Migrate XAS App to New Repository

### DIFF
--- a/src/aiida_qe_xspec/gui/xas/__init__.py
+++ b/src/aiida_qe_xspec/gui/xas/__init__.py
@@ -3,7 +3,7 @@ from importlib import resources as importlib_resources
 import yaml
 
 from aiidalab_qe.common.panel import PluginOutline
-from aiidalab_qe.plugins import xas as xas_folder
+from aiida_qe_xspec.gui import xas as xas_folder
 
 from .model import XasConfigurationSettingsModel
 from .resources import XasResourceSettingsModel, XasResourceSettingsPanel

--- a/src/aiida_qe_xspec/gui/xas/model.py
+++ b/src/aiida_qe_xspec/gui/xas/model.py
@@ -10,7 +10,7 @@ import yaml
 from aiida import orm
 from aiidalab_qe.common.mixins import HasInputStructure
 from aiidalab_qe.common.panel import ConfigurationSettingsModel
-from aiidalab_qe.plugins import xas as xas_folder
+from aiida_qe_xspec.gui import xas as xas_folder
 
 
 class XasConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructure):
@@ -85,16 +85,21 @@ class XasConfigurationSettingsModel(ConfigurationSettingsModel, HasInputStructur
     def get_model_state(self):
         pseudo_labels = {}
         core_wfc_data_labels = {}
-        for element in self.kind_names.keys():
-            pseudo_labels[element] = {
-                'gipaw': self.gipaw_pseudos[element],
-                'core_hole': self.core_hole_pseudos[element],
-            }
-            core_wfc_data_labels[element] = self.core_wfc_data_dict[element]
+        for element, is_selected in self.kind_names.items():
+            if is_selected:
+                pseudo_labels[element] = {
+                    'gipaw': self.gipaw_pseudos[element],
+                    'core_hole': self.core_hole_pseudos[element],
+                }
+                core_wfc_data_labels[element] = self.core_wfc_data_dict[element]
+            else:
+                self.core_hole_treatments.pop(element)
+
+        elements_list = [key for key in self.kind_names if self.kind_names[key]]
 
         return {
             # "structure_type": self.structure_type,
-            'elements_list': list(self.kind_names.keys()),
+            'elements_list': elements_list,
             'core_hole_treatments': self.core_hole_treatments,
             'pseudo_labels': pseudo_labels,
             'core_wfc_data_labels': core_wfc_data_labels,

--- a/src/aiida_qe_xspec/gui/xas/result/spectrum_button.py
+++ b/src/aiida_qe_xspec/gui/xas/result/spectrum_button.py
@@ -1,15 +1,15 @@
 import base64
-import hashlib
 from typing import Callable
 
 import ipywidgets as ipw
-from IPython.display import HTML, display
 
 
 class SpectrumDownloadButton(ipw.Button):
-    """Download button with dynamic content
-    The content is generated using a callback when the button is clicked.
-    Modified from responses to https://stackoverflow.com/questions/61708701/how-to-download-a-file-using-ipywidget-button#62641240
+    """Download button with dynamic content.
+
+    Javascript solution copied from AiiDALab-QE
+    archive download function.
+    (see: https://github.com/aiidalab/aiidalab-qe/blob/main/src/aiidalab_qe/app/result/components/summary/download_data.py)
     """
 
     def __init__(self, filename: str, contents: Callable[[], str], **kwargs):
@@ -19,29 +19,21 @@ class SpectrumDownloadButton(ipw.Button):
         self.on_click(self.__on_click)
 
     def __on_click(self, _):
+        from IPython.display import Javascript, display
         if self.contents is None:
             return
 
         contents: bytes = self.contents().encode('utf-8')
         b64 = base64.b64encode(contents)
         payload = b64.decode()
-        digest = hashlib.md5(contents).hexdigest()  # bypass browser cache
-        link_id = f'dl_{digest}'
-
-        display(
-            HTML(
-                f"""
-            <html>
-            <body>
-            <a id="{link_id}" download="{self.filename}" href="data:text/csv;base64,{payload}" download>
-            </a>
-            <script>
-            (function download() {{
-            document.getElementById('{id}').click();
-            }})()
-            </script>
-            </body>
-            </html>
-        """
-            )
+        javas = Javascript(
+            f"""
+            var link = document.createElement('a');
+            link.href = 'data:application;base64,{payload}'
+            link.download = '{self.filename}'
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            """
         )
+        display(javas)

--- a/src/aiida_qe_xspec/gui/xas/workchain.py
+++ b/src/aiida_qe_xspec/gui/xas/workchain.py
@@ -5,7 +5,7 @@ import yaml
 from aiida import orm
 from aiida.plugins import WorkflowFactory
 from aiida_quantumespresso.common.types import ElectronicType, SpinType
-from aiidalab_qe.plugins import xas as xas_folder
+from aiida_qe_xspec.gui import xas as xas_folder
 from aiidalab_qe.utils import (
     enable_pencil_decomposition,
     set_component_resources,


### PR DESCRIPTION
Makes necessary changes to migrate the XAS app from AiiDAlab-QE to this repository.

Additionally fixes two bugs discovered during testing:
* Element selection via the tickbox widgets in the XAS settings panel did not work due to a previous change in `aiidalab-qe` which did not return the elements selected to the main workchain. This fix now ensures that both `elements_list` and `core_hole_treatments` are updated correctly for the elements which are selected.
* The `spectrum_button` failed to download the spectrum when pressed. The original solution using HTML has been replaced with the Javascript solution used by AiiDAlab-QE for archive downloading.