### PR TITLE
Updated import paths, namespaces name

### DIFF
--- a/src/aiida_qe_xspec/calculations/xspectra.py
+++ b/src/aiida_qe_xspec/calculations/xspectra.py
@@ -27,7 +27,7 @@ class XspectraCalculation(NamelistsCalculation):
     _internal_retrieve_list = [_Spectrum_FILENAME]
     _retrieve_singlefile_list = []
     _retrieve_temporary_list = []
-    _default_parser = 'quantumespresso.xspectra'
+    _default_parser = 'xspec.xspectra'
 
     @classmethod
     def define(cls, spec):
@@ -131,7 +131,7 @@ class XspectraCalculation(NamelistsCalculation):
         parent_folder = self.inputs.parent_folder
         parent_calc = parent_folder.creator
 
-        if parent_calc.process_type == 'aiida.calculations:quantumespresso.xspectra':
+        if parent_calc.process_type == 'aiida.calculations:xspec.xspectra':
             calcinfo.remote_copy_list.append((
                 parent_folder.computer.uuid, os.path.join(parent_folder.get_remote_path(),
                                                           self._XSPECTRA_SAVE_FILE), '.'

--- a/src/aiida_qe_xspec/workflows/functions/get_xspectra_structures.py
+++ b/src/aiida_qe_xspec/workflows/functions/get_xspectra_structures.py
@@ -136,7 +136,7 @@ def get_supercell(structure, supercell_min_parameter, is_hubbard_structure, **kw
     blank_supercell = StructureData(ase=ase_supercell)
     new_supercell = StructureData()
     new_supercell.set_cell(blank_supercell.cell)
-    num_extensions = np.product(multiples)
+    num_extensions = np.prod(multiples)
     types_order = kwargs['types_order']
     type_mapping_dict = kwargs['type_mapping_dict']
     supercell_types_order = []

--- a/src/aiida_qe_xspec/workflows/xps.py
+++ b/src/aiida_qe_xspec/workflows/xps.py
@@ -355,6 +355,7 @@ class XpsWorkChain(ProtocolMixin, WorkChain):
         spec.output(
             'binding_energies',
             valid_type=orm.Dict,
+            required=False,
             help='All the binding energy values for each element calculated by the WorkChain.'
         )
         spec.output_namespace(
@@ -366,6 +367,7 @@ class XpsWorkChain(ProtocolMixin, WorkChain):
         spec.output_namespace(
             'binding_energy_spectra',
             valid_type=orm.XyData,
+            required=False,
             dynamic=True,
             help='The fully-resolved spectra for each element based on binding energy.'
         )
@@ -543,7 +545,8 @@ class XpsWorkChain(ProtocolMixin, WorkChain):
                 kpoints_mesh = DataFactory('core.array.kpoints')()
                 kpoints_mesh.set_kpoints_mesh([1, 1, 1])
                 builder.ch_scf.kpoints = kpoints_mesh
-                builder.relax.base.pw.settings = orm.Dict(dict={'gamma_only': True})
+                builder.relax.base_init_relax.pw.settings = orm.Dict(dict={'gamma_only': True})
+                builder.relax.base_relax.pw.settings = orm.Dict(dict={'gamma_only': True})
         # pylint: enable=no-member
         return builder
 

--- a/src/aiida_qe_xspec/workflows/xspectra/crystal.py
+++ b/src/aiida_qe_xspec/workflows/xspectra/crystal.py
@@ -9,7 +9,7 @@ from aiida.orm import UpfData as aiida_core_upf
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida_pseudo.data.pseudo import UpfData as aiida_pseudo_upf
 
-from aiida_quantumespresso.calculations.functions.xspectra.get_spectra_by_element import get_spectra_by_element
+from aiida_qe_xspec.calculations.functions.xspectra.get_spectra_by_element import get_spectra_by_element
 from aiida_quantumespresso.utils.hubbard import HubbardStructureData
 from aiida_quantumespresso.utils.mapping import prepare_process_inputs
 from aiida_quantumespresso.workflows.protocols.utils import ProtocolMixin, recursive_merge


### PR DESCRIPTION
Dear all,
I have updated some import paths that were pointing to the old aiida-quantumespresso implementation.
I updated also the namespaces for `PwRelaxWorkChain` (now compatible with aiida-qe v5.0.x)
I made optional the absolute `binding_energies` and relative output `binding_energy_spectra`