### PR TITLE
Support XPS total magnetization inputs

### DIFF
--- a/src/aiida_qe_xspec/gui/xps/result/result.py
+++ b/src/aiida_qe_xspec/gui/xps/result/result.py
@@ -281,10 +281,11 @@ class XpsResultsPanel(ResultsPanel[XpsResultsModel]):
         element, orbital = self.spectrum_select.value.split('_')
 
         for key, value in self._model.binding_energies[element][orbital].items():
-            site_index = key.split('_')[-1]
+            atom_index = int(key.split('_')[-1])
             data.append(
                 {
-                    'site_index': site_index,
+                    'site_index': atom_index + 1,
+                    'atom_index': atom_index,
                     'element': element,
                     'chemical_shift': round(self._model.chemical_shifts[element][orbital][key]['energy'], 2),
                     'binding_energy': round(value['energy'], 2),
@@ -304,6 +305,5 @@ class XpsResultsPanel(ResultsPanel[XpsResultsModel]):
     def _on_row_index_change(self, change):
         if change['new'] is not None:
             row_index = int(change['new'])
-            # The first row is the header, so we do +1 offset.
-            site_idx = self.result_table.data[row_index]['site_index']
-            self.structure_view.avr.selected_atoms_indices = [site_idx]
+            atom_index = self.result_table.data[row_index]['atom_index']
+            self.structure_view.avr.selected_atoms_indices = [atom_index]

--- a/src/aiida_qe_xspec/gui/xps/setting.py
+++ b/src/aiida_qe_xspec/gui/xps/setting.py
@@ -69,7 +69,7 @@ class XpsConfigurationSettingsPanel(
             (self._model, 'atom_indices'),
             (self.atom_indices_input, 'value'),
             [
-                lambda value: ', '.join(value),
+                lambda value: ', '.join(str(index) for index in value),
                 lambda value: [int(i.strip()) for i in value.split(',') if i.strip()],
             ],
         )

--- a/src/aiida_qe_xspec/gui/xps/workchain.py
+++ b/src/aiida_qe_xspec/gui/xps/workchain.py
@@ -1,5 +1,5 @@
 from aiida.common import ValidationError
-from aiida.orm import Bool, Dict, Float, Group, QueryBuilder
+from aiida.orm import Bool, Dict, Float, Group
 from aiida.plugins import WorkflowFactory
 from aiida_quantumespresso.common.types import ElectronicType, SpinType
 from aiida_qe_xspec.workflows.xps import XpsWorkChain
@@ -63,7 +63,7 @@ def get_builder(codes, structure, parameters, **kwargs):
     atom_indices = xps_parameters.pop('atom_indices', None)
     # load pseudo for excited-state and group-state.
     pseudo_group_label = xps_parameters.pop('pseudo_group')
-    pseudo_group = QueryBuilder().append(Group, filters={'label': pseudo_group_label}).one()[0]
+    pseudo_group = Group.collection.get(label=pseudo_group_label)
     if atom_indices:
         atom_indices, inferred_core_levels = _core_levels_for_atom_indices(structure, atom_indices, pseudo_group)
         if not core_levels:

--- a/src/aiida_qe_xspec/gui/xps/workchain.py
+++ b/src/aiida_qe_xspec/gui/xps/workchain.py
@@ -1,3 +1,4 @@
+from aiida.common import ValidationError
 from aiida.orm import Bool, Dict, Float, Group, QueryBuilder
 from aiida.plugins import WorkflowFactory
 from aiida_quantumespresso.common.types import ElectronicType, SpinType
@@ -16,6 +17,37 @@ supercell_min_parameter_map = {
 }
 
 
+def _core_levels_for_atom_indices(structure, atom_indices, pseudo_group):
+    """Return zero-based atom indices and supported core levels for selected one-based UI indices."""
+    if not atom_indices:
+        return atom_indices, {}
+
+    correction_energies = pseudo_group.base.extras.get('correction', {})
+    supported_core_levels = {}
+    for key in correction_energies:
+        element, orbital = key.split('_', maxsplit=1)
+        supported_core_levels.setdefault(element, []).append(orbital)
+
+    zero_based_indices = []
+    core_levels = {}
+    num_sites = len(structure.sites)
+    for index in atom_indices:
+        if index < 1 or index > num_sites:
+            raise ValidationError(
+                f'Atom index {index} is out of range. Use one-based indices between 1 and {num_sites}.'
+            )
+        zero_based_index = index - 1
+        zero_based_indices.append(zero_based_index)
+        kind = structure.get_kind(structure.sites[zero_based_index].kind_name)
+        element = kind.symbol
+        if element not in supported_core_levels:
+            raise ValidationError(
+                f'Element {element} for atom index {index} is not supported by pseudo group {pseudo_group.label}.'
+            )
+        core_levels.setdefault(element, supported_core_levels[element])
+
+    return zero_based_indices, core_levels
+
 def update_resources(builder, codes):
     """Update the resources for the builder."""
     set_component_resources(builder.ch_scf.pw, codes.get('pw'))
@@ -30,8 +62,13 @@ def get_builder(codes, structure, parameters, **kwargs):
     core_levels = xps_parameters.pop('core_levels')
     atom_indices = xps_parameters.pop('atom_indices', None)
     # load pseudo for excited-state and group-state.
-    pseudo_group = xps_parameters.pop('pseudo_group')
-    core_hole_pseudos, correction_energies = load_core_hole_pseudos(core_levels, pseudo_group)
+    pseudo_group_label = xps_parameters.pop('pseudo_group')
+    pseudo_group = QueryBuilder().append(Group, filters={'label': pseudo_group_label}).one()[0]
+    if atom_indices:
+        atom_indices, inferred_core_levels = _core_levels_for_atom_indices(structure, atom_indices, pseudo_group)
+        if not core_levels:
+            core_levels = inferred_core_levels
+    core_hole_pseudos, correction_energies = load_core_hole_pseudos(core_levels, pseudo_group_label)
     # update the correction energies by the band gap correction
     band_gap_correction = xps_parameters.pop('band_gap_correction', 0.0)
     for element, levels in correction_energies.items():
@@ -53,10 +90,6 @@ def get_builder(codes, structure, parameters, **kwargs):
     if is_molecule_input:
         overrides_ch_scf['pw']['parameters']['SYSTEM']['assume_isolated'] = 'mt'
     overrides = {
-        'relax': {
-            'base': deepcopy(parameters['advanced']),
-            'base_final_scf': deepcopy(parameters['advanced']),
-        },
         'ch_scf': overrides_ch_scf,
     }
     # Ensure that VdW corrections are not applied for the core-hole SCF calculation
@@ -80,7 +113,7 @@ def get_builder(codes, structure, parameters, **kwargs):
         overrides=overrides,
         **kwargs,
     )
-    builder.pop('relax')
+    builder.pop('relax', None)
     builder.pop('clean_workdir', None)
     # update resources
     update_resources(builder, codes)

--- a/src/aiida_qe_xspec/workflows/functions/get_core_hole_inputs.py
+++ b/src/aiida_qe_xspec/workflows/functions/get_core_hole_inputs.py
@@ -3,8 +3,6 @@
 
 Returns a `dict` object with suitable inputs for a subsequent PwCalculation
 """
-from copy import deepcopy
-
 from aiida.common import ValidationError
 
 
@@ -55,8 +53,12 @@ def get_core_hole_inputs(structure, treatment, parameters, abs_site_data, **kwar
     abs_atom_marker = kwargs.get('abs_atom_marker', 'X')
     site_index = abs_site_data['site_index']
     abs_atom_kind = abs_site_data.get('kind_name', abs_site_data['symbol'])
-    updated_parameters = deepcopy(parameters)
+    updated_parameters = parameters.copy()
+    updated_parameters['SYSTEM'] = parameters['SYSTEM'].copy()
     starting_mag = updated_parameters['SYSTEM'].get('starting_magnetization', None)
+    if starting_mag is not None:
+        starting_mag = starting_mag.copy()
+        updated_parameters['SYSTEM']['starting_magnetization'] = starting_mag
     tot_mag = updated_parameters['SYSTEM'].get('tot_magnetization', None)
     if not starting_mag and tot_mag is None and updated_parameters['SYSTEM'].get('nspin', None) == 2:
         raise ValidationError(

--- a/src/aiida_qe_xspec/workflows/functions/get_core_hole_inputs.py
+++ b/src/aiida_qe_xspec/workflows/functions/get_core_hole_inputs.py
@@ -3,6 +3,8 @@
 
 Returns a `dict` object with suitable inputs for a subsequent PwCalculation
 """
+from copy import deepcopy
+
 from aiida.common import ValidationError
 
 
@@ -53,14 +55,14 @@ def get_core_hole_inputs(structure, treatment, parameters, abs_site_data, **kwar
     abs_atom_marker = kwargs.get('abs_atom_marker', 'X')
     site_index = abs_site_data['site_index']
     abs_atom_kind = abs_site_data.get('kind_name', abs_site_data['symbol'])
-    updated_parameters = parameters.copy()
-    starting_mag = parameters['SYSTEM'].get('starting_magnetization', None)
-    if not starting_mag and parameters['SYSTEM'].get('nspin', None) == 2:
+    updated_parameters = deepcopy(parameters)
+    starting_mag = updated_parameters['SYSTEM'].get('starting_magnetization', None)
+    tot_mag = updated_parameters['SYSTEM'].get('tot_magnetization', None)
+    if not starting_mag and tot_mag is None and updated_parameters['SYSTEM'].get('nspin', None) == 2:
         raise ValidationError(
-            'A spin-polarised calculation was requested, but no starting magnetization was provided.'
+            'A spin-polarised calculation was requested, but neither starting nor total magnetization was provided.'
         )
-    tot_mag = parameters['SYSTEM'].get('tot_magnetization', None)
-    tot_charge = parameters['SYSTEM'].get('tot_charge', 0)
+    tot_charge = updated_parameters['SYSTEM'].get('tot_charge', 0)
     afm_inputs = {
         'structure': structure,
         'starting_mag': starting_mag,
@@ -120,24 +122,31 @@ def get_core_hole_inputs(structure, treatment, parameters, abs_site_data, **kwar
         if system_afm:
             starting_mag, tot_mag = _process_afm_system(**afm_inputs)
         elif updated_parameters['SYSTEM'].get('nspin') == 2:
-            starting_mag[abs_atom_marker] = 1
-            tot_mag += 1
+            if starting_mag:
+                starting_mag[abs_atom_marker] = 1
+            if tot_mag is not None:
+                tot_mag += 1
         else:
             starting_mag = {abs_atom_marker: 1}
             updated_parameters['SYSTEM']['nspin'] = 2
             if updated_parameters['SYSTEM'].get('occupations', None) == 'fixed':
-                if tot_mag:
+                if tot_mag is not None:
                     tot_mag += 1
                 else:
                     tot_mag = 1
 
     updated_parameters['SYSTEM']['tot_charge'] = tot_charge
-    if updated_parameters['SYSTEM'].get('nspin') == 2:
-        for kind in structure.get_kind_names():
+    if updated_parameters['SYSTEM'].get('nspin') == 2 and starting_mag:
+        structure_kind_names = structure.get_kind_names()
+        starting_mag = {
+            kind: value for kind, value in starting_mag.items()
+            if kind in structure_kind_names
+        }
+        for kind in structure_kind_names:
             if kind not in starting_mag:
                 starting_mag[kind] = 0
         updated_parameters['SYSTEM']['starting_magnetization'] = starting_mag
-        if tot_mag:
-            updated_parameters['SYSTEM']['tot_magnetization'] = tot_mag
+    if tot_mag is not None:
+        updated_parameters['SYSTEM']['tot_magnetization'] = tot_mag
 
     return updated_parameters

--- a/src/aiida_qe_xspec/workflows/functions/get_core_hole_inputs.py
+++ b/src/aiida_qe_xspec/workflows/functions/get_core_hole_inputs.py
@@ -30,7 +30,7 @@ def _process_afm_system(**kwargs):
     target_site_mag = starting_mag[abs_atom_kind]
 
     final_starting_mag[abs_atom_marker] = target_site_mag
-    if treatment not in ['full', 'FCH']:
+    if treatment not in ['full', 'FCH'] and tot_mag is not None:
         if target_site_mag >= 0:
             tot_mag += 1
         else:

--- a/src/aiida_qe_xspec/workflows/functions/get_marked_structures.py
+++ b/src/aiida_qe_xspec/workflows/functions/get_marked_structures.py
@@ -49,6 +49,6 @@ def get_marked_structures(structure, atom_indices, marker='X'):
                 marked_structure.append_site(new_site)
         result[f'site_{index}'] = marked_structure
 
-    result['output_parameters'] = orm.Dict(dict=output_params)
+    result['output_parameters'] = orm.Dict(dict={'equivalent_sites_data': output_params})
 
     return result

--- a/src/aiida_qe_xspec/workflows/functions/get_marked_structures.py
+++ b/src/aiida_qe_xspec/workflows/functions/get_marked_structures.py
@@ -30,11 +30,18 @@ def get_marked_structures(structure, atom_indices, marker='X'):
 
         for i, site in enumerate(structure.sites):
             if i == index:
-                marked_kind = Kind(name=marker, symbols=site.kind_name)
+                site_kind = kinds[site.kind_name]
+                marked_kind = Kind(name=marker, symbols=site_kind.symbol)
                 marked_site = Site(kind_name=marked_kind.name, position=site.position)
                 marked_structure.append_kind(marked_kind)
                 marked_structure.append_site(marked_site)
-                output_params[f'site_{index}'] = {'symbol': site.kind_name, 'multiplicity': 1}
+                output_params[f'site_{index}'] = {
+                    'kind_name': site.kind_name,
+                    'symbol': site_kind.symbol,
+                    'site_index': index,
+                    'multiplicity': 1,
+                    'equivalent_sites_list': [index],
+                }
             else:
                 if site.kind_name not in [kind.name for kind in marked_structure.kinds]:
                     marked_structure.append_kind(kinds[site.kind_name])

--- a/src/aiida_qe_xspec/workflows/functions/get_xspectra_structures.py
+++ b/src/aiida_qe_xspec/workflows/functions/get_xspectra_structures.py
@@ -44,6 +44,7 @@ def process_molecule_input(structure, **kwargs):  # pylint: disable=too-many-sta
         if site_symbol in abs_elements_list:
             equivalency_dict[f'site_{key}'] = {}
             atom_no_set = eq_atoms_data[key]
+            equivalency_dict[f'site_{key}']['kind_name'] = structure.sites[key].kind_name
             equivalency_dict[f'site_{key}']['site_index'] = key
             equivalency_dict[f'site_{key}']['equivalent_sites_list'] = atom_no_set
             equivalency_dict[f'site_{key}']['multiplicity'] = len(atom_no_set)

--- a/src/aiida_qe_xspec/workflows/xps.py
+++ b/src/aiida_qe_xspec/workflows/xps.py
@@ -421,23 +421,26 @@ class XpsWorkChain(ProtocolMixin, WorkChain):
         inputs = cls.get_protocol_inputs(protocol, overrides)
         pw_args = (code, structure, protocol)
 
-        relax = PwRelaxWorkChain.get_builder_from_protocol(
-            *pw_args, overrides=inputs.get('relax', None), options=options, **kwargs
-        )
+        relax = None
+        if 'relax' in inputs:
+            relax = PwRelaxWorkChain.get_builder_from_protocol(
+                *pw_args, overrides=inputs.get('relax', None), options=options, **kwargs
+            )
+            relax.pop('clean_workdir', None)
+            relax.pop('structure', None)
+            relax.pop('base_final_scf', None)
+
         ch_scf = PwBaseWorkChain.get_builder_from_protocol(
             *pw_args, overrides=inputs.get('ch_scf', None), options=options, **kwargs
         )
-
-        relax.pop('clean_workdir', None)
-        relax.pop('structure', None)
-        relax.pop('base_final_scf', None)
         ch_scf.pop('clean_workdir', None)
         ch_scf.pop('structure', None)
 
         abs_atom_marker = orm.Str(inputs['abs_atom_marker'])
         # pylint: disable=no-member
         builder = cls.get_builder()
-        builder.relax = relax
+        if relax is not None:
+            builder.relax = relax
         builder.ch_scf = ch_scf
         builder.structure = structure
         builder.abs_atom_marker = abs_atom_marker
@@ -468,7 +471,8 @@ class XpsWorkChain(ProtocolMixin, WorkChain):
                 kpoints_mesh = DataFactory('core.array.kpoints')()
                 kpoints_mesh.set_kpoints_mesh([1, 1, 1])
                 builder.ch_scf.kpoints = kpoints_mesh
-                builder.relax.base.pw.settings = orm.Dict(dict={'gamma_only': True})
+                if relax is not None:
+                    builder.relax.base.pw.settings = orm.Dict(dict={'gamma_only': True})
                 # These are the correct input ports for v5 of AiiDA-QE, but since AiiDALab-QE requires
                 # v4.12.1 this makes the GUI part of the plugin incompatable with v5 of AiiDA-QE.
                 # builder.relax.base_init_relax.pw.settings = orm.Dict(dict={'gamma_only': True})

--- a/src/aiida_qe_xspec/workflows/xps.py
+++ b/src/aiida_qe_xspec/workflows/xps.py
@@ -592,11 +592,9 @@ class XpsWorkChain(ProtocolMixin, WorkChain):
             }
             result = get_marked_structures(input_structure, **inputs)
             self.ctx.supercell = input_structure
-            self.ctx.equivalent_sites_data = result.pop('output_parameters').get_dict()
-            self.out(
-                'symmetry_analysis_data',
-                orm.Dict(dict={'equivalent_sites_data': self.ctx.equivalent_sites_data}),
-            )
+            out_params = result.pop('output_parameters')
+            self.ctx.equivalent_sites_data = out_params.get_dict()['equivalent_sites_data']
+            self.out('symmetry_analysis_data', out_params)
         else:
             inputs = {
                 'absorbing_elements_list': orm.List(list(self.ctx.core_levels.keys())),

--- a/src/aiida_qe_xspec/workflows/xps.py
+++ b/src/aiida_qe_xspec/workflows/xps.py
@@ -593,6 +593,10 @@ class XpsWorkChain(ProtocolMixin, WorkChain):
             result = get_marked_structures(input_structure, **inputs)
             self.ctx.supercell = input_structure
             self.ctx.equivalent_sites_data = result.pop('output_parameters').get_dict()
+            self.out(
+                'symmetry_analysis_data',
+                orm.Dict(dict={'equivalent_sites_data': self.ctx.equivalent_sites_data}),
+            )
         else:
             inputs = {
                 'absorbing_elements_list': orm.List(list(self.ctx.core_levels.keys())),

--- a/tests/test_get_core_hole_inputs.py
+++ b/tests/test_get_core_hole_inputs.py
@@ -1,0 +1,191 @@
+from aiida import load_profile, orm
+
+from aiida_qe_xspec.workflows.functions.get_core_hole_inputs import get_core_hole_inputs
+from aiida_qe_xspec.workflows.functions.get_xspectra_structures import process_molecule_input
+from aiida_qe_xspec.gui.xps.workchain import _core_levels_for_atom_indices
+from aiida_qe_xspec.workflows.functions.get_marked_structures import get_marked_structures
+
+
+load_profile()
+
+
+def generate_core_hole_structure():
+    structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
+    structure.append_atom(position=(0, 0, 0), symbols='C')
+    structure.append_atom(position=(1, 0, 0), symbols='Co', name='X')
+    return structure
+
+
+def test_full_core_hole_with_total_magnetization_is_charged():
+    parameters = {
+        'SYSTEM': {
+            'nspin': 2,
+            'tot_charge': 0,
+            'tot_magnetization': 3,
+        },
+    }
+
+    updated = get_core_hole_inputs(
+        structure=generate_core_hole_structure(),
+        treatment='full',
+        parameters=parameters,
+        abs_site_data={'site_index': 1, 'symbol': 'Co'},
+    )
+
+    assert updated['SYSTEM']['tot_charge'] == 1
+    assert updated['SYSTEM']['tot_magnetization'] == 3
+    assert 'starting_magnetization' not in updated['SYSTEM']
+
+
+def test_full_core_hole_with_starting_magnetization_is_charged():
+    parameters = {
+        'SYSTEM': {
+            'nspin': 2,
+            'tot_charge': 0,
+            'starting_magnetization': {
+                'C': 0.1,
+                'Co': 0.3,
+            },
+        },
+    }
+
+    updated = get_core_hole_inputs(
+        structure=generate_core_hole_structure(),
+        treatment='full',
+        parameters=parameters,
+        abs_site_data={'site_index': 1, 'symbol': 'Co'},
+    )
+
+    assert updated['SYSTEM']['tot_charge'] == 1
+    assert updated['SYSTEM']['starting_magnetization'] == {
+        'C': 0.1,
+        'X': 0.3,
+    }
+    assert 'tot_magnetization' not in updated['SYSTEM']
+    assert parameters['SYSTEM']['starting_magnetization'] == {
+        'C': 0.1,
+        'Co': 0.3,
+    }
+
+
+def test_excited_core_hole_with_total_magnetization_is_neutral():
+    parameters = {
+        'SYSTEM': {
+            'nspin': 2,
+            'tot_charge': 0,
+            'tot_magnetization': 3,
+        },
+    }
+
+    updated = get_core_hole_inputs(
+        structure=generate_core_hole_structure(),
+        treatment='excited',
+        parameters=parameters,
+        abs_site_data={'site_index': 1, 'symbol': 'Co'},
+    )
+
+    assert updated['SYSTEM']['tot_charge'] == 0
+    assert updated['SYSTEM']['tot_magnetization'] == 4
+    assert 'starting_magnetization' not in updated['SYSTEM']
+
+
+def test_excited_core_hole_with_starting_magnetization_is_neutral():
+    parameters = {
+        'SYSTEM': {
+            'nspin': 2,
+            'tot_charge': 0,
+            'starting_magnetization': {
+                'C': 0.1,
+                'Co': 0.3,
+            },
+        },
+    }
+
+    updated = get_core_hole_inputs(
+        structure=generate_core_hole_structure(),
+        treatment='excited',
+        parameters=parameters,
+        abs_site_data={'site_index': 1, 'symbol': 'Co'},
+    )
+
+    assert updated['SYSTEM']['tot_charge'] == 0
+    assert updated['SYSTEM']['starting_magnetization'] == {
+        'C': 0.1,
+        'X': 1,
+    }
+    assert 'tot_magnetization' not in updated['SYSTEM']
+
+
+def test_molecule_symmetry_data_preserves_kind_name_for_tagged_atoms():
+    structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
+    structure.append_atom(position=(6.1509291, 5, 5), symbols='O', name='O1')
+    structure.append_atom(position=(5, 5, 5), symbols='O', name='O1')
+
+    result = process_molecule_input(structure, absorbing_elements_list=['O'])
+    equivalent_sites_data = result['output_params']['equivalent_sites_data']
+
+    assert equivalent_sites_data['site_1']['symbol'] == 'O'
+    assert equivalent_sites_data['site_1']['kind_name'] == 'O1'
+
+
+def test_starting_magnetization_uses_tagged_absorber_kind_name():
+    structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
+    structure.append_atom(position=(0, 0, 0), symbols='O', name='O1')
+    structure.append_atom(position=(1, 0, 0), symbols='O', name='X')
+    parameters = {
+        'SYSTEM': {
+            'nspin': 2,
+            'tot_charge': 0,
+            'starting_magnetization': {
+                'O1': 0.1,
+            },
+        },
+    }
+
+    updated = get_core_hole_inputs(
+        structure=structure,
+        treatment='full',
+        parameters=parameters,
+        abs_site_data={'site_index': 1, 'symbol': 'O', 'kind_name': 'O1'},
+    )
+
+    assert updated['SYSTEM']['starting_magnetization'] == {
+        'O1': 0.1,
+        'X': 0.1,
+    }
+
+
+def test_atom_indices_are_one_based_in_gui_builder():
+    structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
+    structure.append_atom(position=(0, 0, 0), symbols='C')
+    structure.append_atom(position=(1, 0, 0), symbols='O', name='O1')
+    pseudo_group = orm.Group(label='test_xps_pseudos')
+    pseudo_group.base.extras.set('correction', {
+        'C_1s': {'core': 0.0, 'exp': 0.0},
+        'O_1s': {'core': 0.0, 'exp': 0.0},
+    })
+
+    atom_indices, core_levels = _core_levels_for_atom_indices(structure, [1, 2], pseudo_group)
+
+    assert atom_indices == [0, 1]
+    assert core_levels == {'C': ['1s'], 'O': ['1s']}
+
+
+def test_marked_structures_use_symbol_for_tagged_absorber_kind():
+    structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
+    structure.append_atom(position=(0, 0, 0), symbols='O', name='O1')
+    structure.append_atom(position=(1, 0, 0), symbols='C')
+
+    result = get_marked_structures(
+        structure,
+        atom_indices=orm.List([0]),
+        marker=orm.Str('X'),
+    )
+
+    marked = result['site_0']
+    output_parameters = result['output_parameters'].get_dict()
+
+    assert [(kind.name, kind.symbol) for kind in marked.kinds] == [('X', 'O'), ('C', 'C')]
+    assert [site.kind_name for site in marked.sites] == ['X', 'C']
+    assert output_parameters['site_0']['kind_name'] == 'O1'
+    assert output_parameters['site_0']['symbol'] == 'O'

--- a/tests/test_get_core_hole_inputs.py
+++ b/tests/test_get_core_hole_inputs.py
@@ -9,183 +9,204 @@ from aiida_qe_xspec.workflows.functions.get_marked_structures import get_marked_
 load_profile()
 
 
-def generate_core_hole_structure():
+def generate_formic_acid_structure():
     structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
-    structure.append_atom(position=(0, 0, 0), symbols='C')
-    structure.append_atom(position=(1, 0, 0), symbols='Co', name='X')
+    structure.append_atom(position=(5.000, 5.000, 5.000), symbols="C")
+    structure.append_atom(position=(6.200, 5.000, 5.000), symbols="O", name="O1")
+    structure.append_atom(position=(4.300, 5.900, 5.000), symbols="O", name="O")
+    structure.append_atom(position=(4.500, 4.100, 5.000), symbols="H")
+    structure.append_atom(position=(4.900, 6.700, 5.000), symbols="H")
+    return structure
+
+
+def generate_tagged_oxygen_core_hole_structure():
+    structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
+    structure.append_atom(position=(5.000, 5.000, 5.000), symbols="C")
+    structure.append_atom(position=(6.200, 5.000, 5.000), symbols="O", name="X")
+    structure.append_atom(position=(4.300, 5.900, 5.000), symbols="O", name="O")
+    structure.append_atom(position=(4.500, 4.100, 5.000), symbols="H")
+    structure.append_atom(position=(4.900, 6.700, 5.000), symbols="H")
     return structure
 
 
 def test_full_core_hole_with_total_magnetization_is_charged():
     parameters = {
-        'SYSTEM': {
-            'nspin': 2,
-            'tot_charge': 0,
-            'tot_magnetization': 3,
+        "SYSTEM": {
+            "nspin": 2,
+            "tot_charge": 0,
+            "tot_magnetization": 3,
         },
     }
 
     updated = get_core_hole_inputs(
-        structure=generate_core_hole_structure(),
-        treatment='full',
+        structure=generate_tagged_oxygen_core_hole_structure(),
+        treatment="full",
         parameters=parameters,
-        abs_site_data={'site_index': 1, 'symbol': 'Co'},
+        abs_site_data={"site_index": 1, "symbol": "O", "kind_name": "O1"},
     )
 
-    assert updated['SYSTEM']['tot_charge'] == 1
-    assert updated['SYSTEM']['tot_magnetization'] == 3
-    assert 'starting_magnetization' not in updated['SYSTEM']
+    assert updated["SYSTEM"]["tot_charge"] == 1
+    assert updated["SYSTEM"]["tot_magnetization"] == 3
+    assert "starting_magnetization" not in updated["SYSTEM"]
 
 
 def test_full_core_hole_with_starting_magnetization_is_charged():
     parameters = {
-        'SYSTEM': {
-            'nspin': 2,
-            'tot_charge': 0,
-            'starting_magnetization': {
-                'C': 0.1,
-                'Co': 0.3,
+        "SYSTEM": {
+            "nspin": 2,
+            "tot_charge": 0,
+            "starting_magnetization": {
+                "C": 0.1,
+                "O": 0.0,
+                "O1": 0.3,
+                "H": 0.0,
             },
         },
     }
 
     updated = get_core_hole_inputs(
-        structure=generate_core_hole_structure(),
-        treatment='full',
+        structure=generate_tagged_oxygen_core_hole_structure(),
+        treatment="full",
         parameters=parameters,
-        abs_site_data={'site_index': 1, 'symbol': 'Co'},
+        abs_site_data={"site_index": 1, "symbol": "O", "kind_name": "O1"},
     )
 
-    assert updated['SYSTEM']['tot_charge'] == 1
-    assert updated['SYSTEM']['starting_magnetization'] == {
-        'C': 0.1,
-        'X': 0.3,
+    assert updated["SYSTEM"]["tot_charge"] == 1
+    assert updated["SYSTEM"]["starting_magnetization"] == {
+        "C": 0.1,
+        "O": 0.0,
+        "H": 0.0,
+        "X": 0.3,
     }
-    assert 'tot_magnetization' not in updated['SYSTEM']
-    assert parameters['SYSTEM']['starting_magnetization'] == {
-        'C': 0.1,
-        'Co': 0.3,
+    assert "tot_magnetization" not in updated["SYSTEM"]
+    assert parameters["SYSTEM"]["starting_magnetization"] == {
+        "C": 0.1,
+        "O": 0.0,
+        "O1": 0.3,
+        "H": 0.0,
     }
 
 
 def test_excited_core_hole_with_total_magnetization_is_neutral():
     parameters = {
-        'SYSTEM': {
-            'nspin': 2,
-            'tot_charge': 0,
-            'tot_magnetization': 3,
+        "SYSTEM": {
+            "nspin": 2,
+            "tot_charge": 0,
+            "tot_magnetization": 3,
         },
     }
 
     updated = get_core_hole_inputs(
-        structure=generate_core_hole_structure(),
-        treatment='excited',
+        structure=generate_tagged_oxygen_core_hole_structure(),
+        treatment="excited",
         parameters=parameters,
-        abs_site_data={'site_index': 1, 'symbol': 'Co'},
+        abs_site_data={"site_index": 1, "symbol": "O", "kind_name": "O1"},
     )
 
-    assert updated['SYSTEM']['tot_charge'] == 0
-    assert updated['SYSTEM']['tot_magnetization'] == 4
-    assert 'starting_magnetization' not in updated['SYSTEM']
+    assert updated["SYSTEM"]["tot_charge"] == 0
+    assert updated["SYSTEM"]["tot_magnetization"] == 4
+    assert "starting_magnetization" not in updated["SYSTEM"]
 
 
 def test_excited_core_hole_with_starting_magnetization_is_neutral():
     parameters = {
-        'SYSTEM': {
-            'nspin': 2,
-            'tot_charge': 0,
-            'starting_magnetization': {
-                'C': 0.1,
-                'Co': 0.3,
+        "SYSTEM": {
+            "nspin": 2,
+            "tot_charge": 0,
+            "starting_magnetization": {
+                "C": 0.1,
+                "O": 0.0,
+                "O1": 0.3,
+                "H": 0.0,
             },
         },
     }
 
     updated = get_core_hole_inputs(
-        structure=generate_core_hole_structure(),
-        treatment='excited',
+        structure=generate_tagged_oxygen_core_hole_structure(),
+        treatment="excited",
         parameters=parameters,
-        abs_site_data={'site_index': 1, 'symbol': 'Co'},
+        abs_site_data={"site_index": 1, "symbol": "O", "kind_name": "O1"},
     )
 
-    assert updated['SYSTEM']['tot_charge'] == 0
-    assert updated['SYSTEM']['starting_magnetization'] == {
-        'C': 0.1,
-        'X': 1,
+    assert updated["SYSTEM"]["tot_charge"] == 0
+    assert updated["SYSTEM"]["starting_magnetization"] == {
+        "C": 0.1,
+        "O": 0.0,
+        "H": 0.0,
+        "X": 1,
     }
-    assert 'tot_magnetization' not in updated['SYSTEM']
+    assert "tot_magnetization" not in updated["SYSTEM"]
 
 
 def test_molecule_symmetry_data_preserves_kind_name_for_tagged_atoms():
-    structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
-    structure.append_atom(position=(6.1509291, 5, 5), symbols='O', name='O1')
-    structure.append_atom(position=(5, 5, 5), symbols='O', name='O1')
+    result = process_molecule_input(generate_formic_acid_structure(), absorbing_elements_list=["O"])
+    equivalent_sites_data = result["output_params"]["equivalent_sites_data"]
 
-    result = process_molecule_input(structure, absorbing_elements_list=['O'])
-    equivalent_sites_data = result['output_params']['equivalent_sites_data']
+    oxygen_sites = [data for data in equivalent_sites_data.values() if data["symbol"] == "O"]
 
-    assert equivalent_sites_data['site_1']['symbol'] == 'O'
-    assert equivalent_sites_data['site_1']['kind_name'] == 'O1'
+    assert len(oxygen_sites) == 2
+    assert {data["kind_name"] for data in oxygen_sites} == {"O", "O1"}
 
 
 def test_starting_magnetization_uses_tagged_absorber_kind_name():
     structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
-    structure.append_atom(position=(0, 0, 0), symbols='O', name='O1')
-    structure.append_atom(position=(1, 0, 0), symbols='O', name='X')
+    structure.append_atom(position=(0, 0, 0), symbols="O", name="O1")
+    structure.append_atom(position=(1, 0, 0), symbols="O", name="X")
     parameters = {
-        'SYSTEM': {
-            'nspin': 2,
-            'tot_charge': 0,
-            'starting_magnetization': {
-                'O1': 0.1,
+        "SYSTEM": {
+            "nspin": 2,
+            "tot_charge": 0,
+            "starting_magnetization": {
+                "O1": 0.1,
             },
         },
     }
 
     updated = get_core_hole_inputs(
         structure=structure,
-        treatment='full',
+        treatment="full",
         parameters=parameters,
-        abs_site_data={'site_index': 1, 'symbol': 'O', 'kind_name': 'O1'},
+        abs_site_data={"site_index": 1, "symbol": "O", "kind_name": "O1"},
     )
 
-    assert updated['SYSTEM']['starting_magnetization'] == {
-        'O1': 0.1,
-        'X': 0.1,
+    assert updated["SYSTEM"]["starting_magnetization"] == {
+        "O1": 0.1,
+        "X": 0.1,
     }
 
 
 def test_atom_indices_are_one_based_in_gui_builder():
     structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
-    structure.append_atom(position=(0, 0, 0), symbols='C')
-    structure.append_atom(position=(1, 0, 0), symbols='O', name='O1')
-    pseudo_group = orm.Group(label='test_xps_pseudos')
-    pseudo_group.base.extras.set('correction', {
-        'C_1s': {'core': 0.0, 'exp': 0.0},
-        'O_1s': {'core': 0.0, 'exp': 0.0},
+    structure.append_atom(position=(0, 0, 0), symbols="C")
+    structure.append_atom(position=(1, 0, 0), symbols="O", name="O1")
+    pseudo_group = orm.Group(label="test_xps_pseudos")
+    pseudo_group.base.extras.set("correction", {
+        "C_1s": {"core": 0.0, "exp": 0.0},
+        "O_1s": {"core": 0.0, "exp": 0.0},
     })
 
     atom_indices, core_levels = _core_levels_for_atom_indices(structure, [1, 2], pseudo_group)
 
     assert atom_indices == [0, 1]
-    assert core_levels == {'C': ['1s'], 'O': ['1s']}
+    assert core_levels == {"C": ["1s"], "O": ["1s"]}
 
 
 def test_marked_structures_use_symbol_for_tagged_absorber_kind():
     structure = orm.StructureData(cell=[[10, 0, 0], [0, 10, 0], [0, 0, 10]])
-    structure.append_atom(position=(0, 0, 0), symbols='O', name='O1')
-    structure.append_atom(position=(1, 0, 0), symbols='C')
+    structure.append_atom(position=(0, 0, 0), symbols="O", name="O1")
+    structure.append_atom(position=(1, 0, 0), symbols="C")
 
     result = get_marked_structures(
         structure,
         atom_indices=orm.List([0]),
-        marker=orm.Str('X'),
+        marker=orm.Str("X"),
     )
 
-    marked = result['site_0']
-    output_parameters = result['output_parameters'].get_dict()['equivalent_sites_data']
+    marked = result["site_0"]
+    output_parameters = result["output_parameters"].get_dict()["equivalent_sites_data"]
 
-    assert [(kind.name, kind.symbol) for kind in marked.kinds] == [('X', 'O'), ('C', 'C')]
-    assert [site.kind_name for site in marked.sites] == ['X', 'C']
-    assert output_parameters['site_0']['kind_name'] == 'O1'
-    assert output_parameters['site_0']['symbol'] == 'O'
+    assert [(kind.name, kind.symbol) for kind in marked.kinds] == [("X", "O"), ("C", "C")]
+    assert [site.kind_name for site in marked.sites] == ["X", "C"]
+    assert output_parameters["site_0"]["kind_name"] == "O1"
+    assert output_parameters["site_0"]["symbol"] == "O"

--- a/tests/test_get_core_hole_inputs.py
+++ b/tests/test_get_core_hole_inputs.py
@@ -139,6 +139,37 @@ def test_excited_core_hole_with_starting_magnetization_is_neutral():
     assert "tot_magnetization" not in updated["SYSTEM"]
 
 
+def test_excited_core_hole_with_afm_starting_magnetization_without_total_magnetization():
+    parameters = {
+        "SYSTEM": {
+            "nspin": 2,
+            "tot_charge": 0,
+            "starting_magnetization": {
+                "C": 0.0,
+                "O": -0.2,
+                "O1": 0.3,
+                "H": 0.0,
+            },
+        },
+    }
+
+    updated = get_core_hole_inputs(
+        structure=generate_tagged_oxygen_core_hole_structure(),
+        treatment="excited",
+        parameters=parameters,
+        abs_site_data={"site_index": 1, "symbol": "O", "kind_name": "O1"},
+    )
+
+    assert updated["SYSTEM"]["tot_charge"] == 0
+    assert updated["SYSTEM"]["starting_magnetization"] == {
+        "C": 0.0,
+        "O": -0.2,
+        "H": 0.0,
+        "X": 0.3,
+    }
+    assert "tot_magnetization" not in updated["SYSTEM"]
+
+
 def test_molecule_symmetry_data_preserves_kind_name_for_tagged_atoms():
     result = process_molecule_input(generate_formic_acid_structure(), absorbing_elements_list=["O"])
     equivalent_sites_data = result["output_params"]["equivalent_sites_data"]

--- a/tests/test_get_core_hole_inputs.py
+++ b/tests/test_get_core_hole_inputs.py
@@ -183,7 +183,7 @@ def test_marked_structures_use_symbol_for_tagged_absorber_kind():
     )
 
     marked = result['site_0']
-    output_parameters = result['output_parameters'].get_dict()
+    output_parameters = result['output_parameters'].get_dict()['equivalent_sites_data']
 
     assert [(kind.name, kind.symbol) for kind in marked.kinds] == [('X', 'O'), ('C', 'C')]
     assert [site.kind_name for site in marked.sites] == ['X', 'C']

--- a/tests/test_xps_inputs_validation.py
+++ b/tests/test_xps_inputs_validation.py
@@ -1,9 +1,9 @@
-from aiida_qe_xspec.utils import load_core_hole_pseudos
-from aiida_qe_xspec.workflows.xps import XpsWorkChain
-from aiida import orm, load_profile
 import pytest
+from aiida import load_profile, orm
 from aiida.common import ValidationError
 from aiida.engine import run
+from aiida_qe_xspec.utils import load_core_hole_pseudos
+from aiida_qe_xspec.workflows.xps import XpsWorkChain
 
 load_profile()
 
@@ -85,3 +85,35 @@ def test_validate_get_builder_from_protocol(etfa_molecule):
             correction_energies=orm.Dict(correction_energies),
         )
         run(builder)
+
+
+def test_builder_allows_total_magnetization_without_starting_magnetization(etfa_molecule):
+    code = orm.load_code('qe-7.2-pw@localhost')
+    core_levels = {'C': ['1s']}
+    core_hole_pseudos, correction_energies = load_core_hole_pseudos(core_levels, 'pseudo_demo_pbe')
+
+    builder = XpsWorkChain.get_builder_from_protocol(
+        structure=etfa_molecule,
+        code=code,
+        core_hole_pseudos=core_hole_pseudos,
+        core_levels=core_levels,
+        correction_energies=orm.Dict(correction_energies),
+        overrides={
+            'ch_scf': {
+                'pw': {
+                    'parameters': {
+                        'SYSTEM': {
+                            'nspin': 2,
+                            'tot_magnetization': 1,
+                        },
+                    },
+                },
+            },
+        },
+    )
+
+    system = builder.ch_scf.pw.parameters.get_dict()['SYSTEM']
+
+    assert system['nspin'] == 2
+    assert system['tot_magnetization'] == 1
+    assert 'starting_magnetization' not in system


### PR DESCRIPTION
## Summary

Fix XPS workflow bugs for spin-polarized systems, tagged atoms, and atom-index selection.

## Current behavior

- Spin with `tot_magnetization`: allowed without `starting_magnetization`.
- Spin with `starting_magnetization`: allowed without `tot_magnetization`; absorber magnetization is moved to `X`.
- Molecules: full core-hole final states remain charged (`tot_charge += 1`).
- Periodic systems: excited core-hole final states remain neutral (`tot_charge` unchanged).
- Atom-index mode: GUI indices are one-based; the workflow receives zero-based indices.

## Bugs fixed

- Spin/core-hole inputs now handle total magnetization and starting magnetization separately.
- Tagged absorber kinds such as `O1` are preserved for magnetization, while the chemical symbol `O` is used for pseudo/core-hole lookup.
- Atom-index submissions infer the needed core levels and write standard `symmetry_analysis_data` outputs.
- Molecule-only XPS submissions no longer build an unused relaxation step.
- The XPS result table now displays one-based site numbers.

## Code pointers

- Spin and charge handling: [`get_core_hole_inputs.py`](https://github.com/cpignedoli/aiida-qe-xspec/blob/fix/xps-spin-starting-magnetization/src/aiida_qe_xspec/workflows/functions/get_core_hole_inputs.py#L52-L150)
- Tagged molecule metadata: [`get_xspectra_structures.py`](https://github.com/cpignedoli/aiida-qe-xspec/blob/fix/xps-spin-starting-magnetization/src/aiida_qe_xspec/workflows/functions/get_xspectra_structures.py#L40-L53)
- Atom-index marked structures: [`get_marked_structures.py`](https://github.com/cpignedoli/aiida-qe-xspec/blob/fix/xps-spin-starting-magnetization/src/aiida_qe_xspec/workflows/functions/get_marked_structures.py#L31-L52)
- GUI atom-index conversion: [`workchain.py`](https://github.com/cpignedoli/aiida-qe-xspec/blob/fix/xps-spin-starting-magnetization/src/aiida_qe_xspec/gui/xps/workchain.py#L20-L49)
- XPS builder/output wiring: [`xps.py`](https://github.com/cpignedoli/aiida-qe-xspec/blob/fix/xps-spin-starting-magnetization/src/aiida_qe_xspec/workflows/xps.py#L433-L469), [`xps.py`](https://github.com/cpignedoli/aiida-qe-xspec/blob/fix/xps-spin-starting-magnetization/src/aiida_qe_xspec/workflows/xps.py#L588-L597)
- Result table site numbering: [`result.py`](https://github.com/cpignedoli/aiida-qe-xspec/blob/fix/xps-spin-starting-magnetization/src/aiida_qe_xspec/gui/xps/result/result.py#L283-L309)

## Tested on formic acid
<img width="845" height="742" alt="image" src="https://github.com/user-attachments/assets/8afd7af3-1dcc-43eb-8bfe-a831459c2532" />
<img width="855" height="773" alt="image" src="https://github.com/user-attachments/assets/6b005cc7-8b81-4db5-814a-d038398087af" />


## Co-authorship

Co-authored with OpenAI Codex.
